### PR TITLE
Jira 123: Sure front end enhancements

### DIFF
--- a/cypress/fixtures/example.json
+++ b/cypress/fixtures/example.json
@@ -1,0 +1,5 @@
+{
+  "name": "Using fixtures to represent data",
+  "email": "hello@cypress.io",
+  "body": "Fixtures are a great way to mock data for responses to routes"
+}

--- a/cypress/fixtures/policyHolders.json
+++ b/cypress/fixtures/policyHolders.json
@@ -1,0 +1,17 @@
+{
+    "policyHolders": [
+        {
+            "name": "Mrs. Holder",
+            "age": 55,
+            "address": {
+                "line1": "123 Lane Ave",
+                "line2": "3H",
+                "city": "Santa Monica",
+                "state": "CA",
+                "postalCode": "90405"
+            },
+            "phoneNumber": "1-989-989-9898",
+            "isPrimary": true
+        }
+    ]
+}

--- a/cypress/integration/happy_path.spec.ts
+++ b/cypress/integration/happy_path.spec.ts
@@ -1,17 +1,27 @@
 /// <reference types="cypress" />
 
 describe('happy path', () => {
+
   it('runs happy path successfully', () => {
     cy.visit('/');
     cy.getTestEl('table_link').should('be.visible');
     cy.getTestEl('you_go_link').should('be.visible');
     cy.getTestEl('policyholders_link').should('be.visible');
 
-    /**
-     * TODO: Challenge 10 - Update this test
-     * - Click the Policyholders sidebar link
-     * - Assert that a network request is made
-     * - Assert that data from the network is displayed
-     */
+    cy.intercept({
+        method: 'GET',
+        url: '/api/policyholders',
+    },{fixture: 'policyHolders.json'}
+    ).as('getPolicyHolders')
+    
+    cy.get('[data-testid="policyholders_link"]').click()
+     
+    cy.wait('@getPolicyHolders', {timeout: 3000}).then((interception) => {
+        expect(interception.response.statusCode).equal(200)
+    })
+     // Cell for 'Age' row value should be visible
+    cy.get(':nth-child(2) > .css-1miykz9-MuiTableCell-root').should('be.visible')
+    // The value in the 'Age' row value cell should match the value in our text fixture, verifying that the data displayed is from the intercepted request
+    cy.get(':nth-child(2) > .css-1miykz9-MuiTableCell-root').contains(55)
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import TableDemoView from './components/TableDemoView';
 import HomeView from './components/HomeView';
 import RedirectView from './components/RedirectView';
 import YouCanDoItView from './components/YouCanDoItView';
+import PolicyholdersView from './components/PolicyholdersView';
 import Layout from './components/Layout';
 import { useState } from 'react';
 import Modal from './components/Modal';
@@ -16,6 +17,7 @@ function App() {
       <Layout onFooterClick={() => setIsModalOpen(true)}>
         <Routes>
           <Route path="/" element={<HomeView />} />
+          <Route path="/policyholders" element={<PolicyholdersView />} />
           <Route path="/table" element={<TableDemoView />} />
           <Route path="/you-can-do-it" element={<YouCanDoItView />} />
           <Route path="*" element={<RedirectView />} />

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -21,6 +21,10 @@ function Footer() {
       sx={{
         background: 'rgba(170,186,205,.2)',
         padding: '16px',
+        position: 'relative',
+        bottom: '0',
+        width: '100%',
+        height: '100%'
       }}
     >
       <Grid container justifyContent="space-around">

--- a/src/components/InstructionsBar/InstructionsBar.test.tsx
+++ b/src/components/InstructionsBar/InstructionsBar.test.tsx
@@ -11,6 +11,10 @@ describe('InstructionsBar', () => {
     expect(getByText('View challenges')).toBeInTheDocument();
   });
 
-  // TODO: Challenge 3
-  it('should call the onClick prop when the button is clicked', () => {});
+  it('should call the onClick prop when the button is clicked', () => {
+    const { getByText } = renderWithProviders(<InstructionsBar {...defaultProps} />);
+    
+    getByText('View challenges').click()
+    expect(defaultProps.onClick).toHaveBeenCalled()
+  });
 });

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -16,6 +16,8 @@ function Layout({ children, onFooterClick }: TLayout) {
         component="main"
         sx={{
           display: 'flex',
+          position: 'relative',
+          minHeight: '100vh'
         }}
       >
         <NavBar links={links} />

--- a/src/components/NavBar/NavBar.test.tsx
+++ b/src/components/NavBar/NavBar.test.tsx
@@ -16,8 +16,16 @@ describe('NavBar', () => {
     expect(getByText('Link1')).toBeInTheDocument();
     expect(getByText('Link2')).toBeInTheDocument();
     expect(getByText('Link3')).toBeInTheDocument();
+
+    // console.log(getByText('Link1'))
   });
 
   // TODO: Challenge 2
-  it('should render an `href` attribute for each link', () => {});
+  it('should render an `href` attribute for each link', () => {
+    const { getByText } = renderWithProviders(<NavBar {...defaultProps} />);
+
+    expect(getByText('Link1')).toHaveAttribute('href', '/link1')
+    expect(getByText('Link2')).toHaveAttribute('href', '/link2')
+    expect(getByText('Link3')).toHaveAttribute('href', '/link3')
+  });
 });

--- a/src/components/NavBar/NavBar.test.tsx
+++ b/src/components/NavBar/NavBar.test.tsx
@@ -17,10 +17,8 @@ describe('NavBar', () => {
     expect(getByText('Link2')).toBeInTheDocument();
     expect(getByText('Link3')).toBeInTheDocument();
 
-    // console.log(getByText('Link1'))
   });
 
-  // TODO: Challenge 2
   it('should render an `href` attribute for each link', () => {
     const { getByText } = renderWithProviders(<NavBar {...defaultProps} />);
 

--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -43,6 +43,7 @@ function NavBar({ links }: TNavBar) {
           style={
             ({ isActive }) => isActive ? activeStyle : {}
           }
+          className={'default'}
           data-testid={dataTestId}
         >
           {text}

--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -1,5 +1,6 @@
 import { Link, Box } from '@mui/material';
-import { Link as RouterLink } from 'react-router-dom';
+import { Link as RouterLink, NavLink } from 'react-router-dom';
+import "./index.css";
 type TNavBar = {
   links: {
     text: string;
@@ -9,6 +10,12 @@ type TNavBar = {
 };
 
 function NavBar({ links }: TNavBar) {
+
+  let activeStyle = {
+    borderRadius: '5px',
+    backgroundColor: 'magenta'
+  };
+
   return (
     <Box
       component="aside"
@@ -28,24 +35,18 @@ function NavBar({ links }: TNavBar) {
       >
         <img src="/surelogo.svg" alt="logo"></img>
       </Link>
-
       {links.map(({ text, href, 'data-testid': dataTestId }) => (
-        <Link
-          component={RouterLink}
+        <NavLink
           key={href}
           to={href}
           color="#fff"
-          underline="hover"
-          sx={{
-            cursor: 'pointer',
-            '&:not(:last-of-type)': {
-              marginBottom: '16px',
-            },
-          }}
+          style={
+            ({ isActive }) => isActive ? activeStyle : {}
+          }
           data-testid={dataTestId}
         >
           {text}
-        </Link>
+        </NavLink>
       ))}
     </Box>
   );

--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -12,8 +12,9 @@ type TNavBar = {
 function NavBar({ links }: TNavBar) {
 
   let activeStyle = {
-    borderRadius: '5px',
-    backgroundColor: 'magenta'
+    borderRadius: '3px',
+    backgroundColor: 'slategrey',
+    border: '2px dashed'
   };
 
   return (

--- a/src/components/NavBar/index.css
+++ b/src/components/NavBar/index.css
@@ -1,0 +1,10 @@
+.default {
+    color: #fff;
+    text-decoration: none;
+    margin-bottom: 16px;
+    cursor: pointer;
+}
+
+a:hover {
+    text-decoration: underline;
+}

--- a/src/components/PolicyholdersView/PolicyholdersView.tsx
+++ b/src/components/PolicyholdersView/PolicyholdersView.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Button, Box } from '@mui/material';
-import InfoTable from '../InfoTable'
+import InfoTable from '../InfoTable';
 
   type TPolicy = {
       address?: object;
@@ -19,26 +19,27 @@ import InfoTable from '../InfoTable'
       value: string;
   }
 
-const policyKeys = ['Name', 'Age', 'Address', 'Phone number', 'Primary policyholder']
+const policyKeys = ['Name', 'Age', 'Address', 'Phone number', 'Primary policyholder'];
+const dataMap: Map<string, TPayload | any> = new Map();
 
 function PolicyholdersView() {
-    const [policyholderData, setPolicyholderData] = useState<Array<TFormattedPolicy>>([])
-    const [postedPolicy, setPostedPolicy] = useState<Array<TFormattedPolicy>>([])
+    const [policyholderData, setPolicyholderData] = useState<Array<TFormattedPolicy>>([]);
+    const [postedPolicy, setPostedPolicy] = useState<Array<TFormattedPolicy>>([]);
   
     const buildRows = (data: TPayload) => {
         let policyArr: Array<TFormattedPolicy> = []
         data.policyHolders.map( (policy: TPolicy) => {
-            const values = Object.values(policy)
+            const values = Object.values(policy);
             policyKeys.map( (k, index) => {
                 if (typeof values[index] !== 'object') {
-                    policyArr.push({key: k, value: values[index].toString()})
+                    policyArr.push({key: k, value: values[index].toString()});
                 } else {
-                    policyArr.push({key: k, value: JSON.stringify(values[index])})
+                    policyArr.push({key: k, value: JSON.stringify(values[index])});
                 }    
-            })
-            return policyArr      
-        })
-        return policyArr
+            });
+            return policyArr;      
+        });
+        return policyArr;
     }
 
     const postPolicy = () => {
@@ -64,12 +65,23 @@ function PolicyholdersView() {
        })
             .then( (response) => response.json())
             .then( (json) => setPostedPolicy(buildRows(json)))
+            .catch( (err) => console.error(err))
     }
 
     useEffect( () => {
-        fetch('https://fe-interview-technical-challenge-api-git-main-sure.vercel.app/api/policyholders')
+        if (!dataMap.has('policyHolders')) {
+            fetch('https://fe-interview-technical-challenge-api-git-main-sure.vercel.app/api/policyholders')
             .then( (response) => response.json())
-            .then( (json) => setPolicyholderData(buildRows(json)))
+            .then( (json) => {
+                setPolicyholderData(buildRows(json))
+                return json;
+            })
+            .then( (json) => dataMap.set('policyHolders', json))
+            .then(() => console.log(dataMap.has('policyHolders')))
+            .catch( (err) => console.error(err))
+        } else {
+            setPolicyholderData(buildRows(dataMap.get('policyHolders')))
+        }
     }, [])
 
     return (

--- a/src/components/PolicyholdersView/PolicyholdersView.tsx
+++ b/src/components/PolicyholdersView/PolicyholdersView.tsx
@@ -34,6 +34,7 @@ function PolicyholdersView() {
     const [policyholderData, setPolicyholderData] = useState<Array<TFormattedPolicy>>([]);
     const [postedPolicy, setPostedPolicy] = useState<Array<TFormattedPolicy>>([]);
   
+    // Take the payload from the back end and build it into the InfoTable row format of {key: '', value: ''}
     const buildRows = (data: TPayload) => {
         let policyArr: Array<TFormattedPolicy> = []
         data.policyHolders.map( (policy: TPolicy) => {
@@ -42,6 +43,7 @@ function PolicyholdersView() {
                 if (typeof values[index] !== 'object') {
                     policyArr.push({key: k, value: values[index].toString()});
                 } else {
+                    // Address returns an object as its value so we destructure and display it as comma seperated values
                     const {city, line1, line2, postalCode, state}: any = values[index];
                     policyArr.push({key: k, value: [line1, line2, city, postalCode, state].toString()});
                 }    
@@ -78,6 +80,7 @@ function PolicyholdersView() {
     }
 
     useEffect( () => {
+        // Here dataMap is used to cache our policyholders api call to prevent unneeded http calls
         if (!dataMap.has('policyHolders')) {
             fetch('https://fe-interview-technical-challenge-api-git-main-sure.vercel.app/api/policyholders')
             .then( (response) => response.json())

--- a/src/components/PolicyholdersView/PolicyholdersView.tsx
+++ b/src/components/PolicyholdersView/PolicyholdersView.tsx
@@ -23,6 +23,7 @@ const policyKeys = ['Name', 'Age', 'Address', 'Phone number', 'Primary policyhol
 
 function PolicyholdersView() {
     const [policyholderData, setPolicyholderData] = useState<Array<TFormattedPolicy>>([])
+    const [postedPolicy, setPostedPolicy] = useState<Array<TFormattedPolicy>>([])
   
     const buildRows = (data: TPayload) => {
         let policyArr: Array<TFormattedPolicy> = []
@@ -62,6 +63,7 @@ function PolicyholdersView() {
             body: JSON.stringify(postPayload)
        })
             .then( (response) => response.json())
+            .then( (json) => setPostedPolicy(buildRows(json)))
     }
 
     useEffect( () => {
@@ -71,29 +73,27 @@ function PolicyholdersView() {
     }, [])
 
     return (
-        <>
-        {
-            policyholderData.length > 0
+        <Box textAlign='center'>
+            {
+                postedPolicy.length > 0
             ?
-                <Box
-                    textAlign='center'
-                >
-                    <InfoTable header="Policyholder Details" rows={policyholderData} /> 
-                    <Button
-                        onClick={postPolicy}
-                        variant="contained"
-                        color="primary"
-                        size="large"
-                        sx={{
-                            marginTop: '20px',
-                            textTransform: 'none'
-                        }}
-                    >
-                        Add a policyholder
-                    </Button>
-                </Box>
-            : null}
-       </>
+                <InfoTable header="Policyholder Details" rows={postedPolicy} />
+            :
+                <InfoTable header="Policyholder Details" rows={policyholderData} />
+            }
+            <Button
+                onClick={postPolicy}
+                variant="contained"
+                color="primary"
+                size="large"
+                sx={{
+                    marginTop: '20px',
+                    textTransform: 'none'
+                 }}
+            >
+                Add a policyholder
+            </Button>
+       </Box>
     )
 }
 

--- a/src/components/PolicyholdersView/PolicyholdersView.tsx
+++ b/src/components/PolicyholdersView/PolicyholdersView.tsx
@@ -1,17 +1,54 @@
 import { useEffect, useState } from 'react';
+import InfoTable from '../InfoTable'
+
+  type TPolicy = {
+      address?: object;
+      age: number;
+      isPrimary: boolean;
+      name: string;
+      phoneNumber: string;
+  }
+
+  type TPayload = {
+      policyHolders: Array<TPolicy>
+  }
+
+  type TFormattedPolicy = {
+      key: string;
+      value: string;
+  }
+
+const policyKeys = ['Name', 'Age', 'Address', 'Phone number', 'Primary policyholder']
 
 function PolicyholdersView() {
-    const [policyholderData, setPolicyholderData] = useState()
+    const [policyholderData, setPolicyholderData] = useState<Array<TFormattedPolicy>>([])
+  
+    const buildRows = (data: TPayload) => {
+        let policyArr: Array<TFormattedPolicy> = []
+        data.policyHolders.map( (policy: TPolicy) => {
+            const values = Object.values(policy)
+            policyKeys.map( (k, index) => {
+                if (typeof values[index] !== 'object') {
+                    policyArr.push({key: k, value: values[index].toString()})
+                } else {
+                    policyArr.push({key: k, value: JSON.stringify(values[index])})
+                }    
+            })
+            return policyArr      
+        })
+        return policyArr
+    }
 
-    console.log(policyholderData)
     useEffect( () => {
         fetch('https://fe-interview-technical-challenge-api-git-main-sure.vercel.app/api/policyholders')
             .then( (response) => response.json())
-            .then( (json) => setPolicyholderData(json))
+            .then( (json) => setPolicyholderData(buildRows(json)))
     }, [])
 
     return (
-        null
+        <>
+        {policyholderData.length > 0 ? <InfoTable header="Policyholder Details" rows={policyholderData} /> : null}
+       </>
     )
 }
 

--- a/src/components/PolicyholdersView/PolicyholdersView.tsx
+++ b/src/components/PolicyholdersView/PolicyholdersView.tsx
@@ -2,8 +2,16 @@ import { useEffect, useState } from 'react';
 import { Button, Box } from '@mui/material';
 import InfoTable from '../InfoTable';
 
+  type TAddress = {
+      city: string;
+      line1: string;
+      line2?: string;
+      state: string;
+      postalCode: string;
+  }
+  
   type TPolicy = {
-      address?: object;
+      address: TAddress;
       age: number;
       isPrimary: boolean;
       name: string;
@@ -34,7 +42,8 @@ function PolicyholdersView() {
                 if (typeof values[index] !== 'object') {
                     policyArr.push({key: k, value: values[index].toString()});
                 } else {
-                    policyArr.push({key: k, value: JSON.stringify(values[index])});
+                    const {city, line1, line2, postalCode, state}: any = values[index];
+                    policyArr.push({key: k, value: [line1, line2, city, postalCode, state].toString()});
                 }    
             });
             return policyArr;      
@@ -44,16 +53,16 @@ function PolicyholdersView() {
 
     const postPolicy = () => {
        const postPayload = {
-        "name": 'Derek',
-        "age": '76',
+        "name": "Derek",
+        "age": "76",
         "address": {
-          "line1": '1412 E 33rd St',
-          "line2": '',
-          "city": 'Minneapolis',
-          "state": 'MN',
-          "postalCode": '55427',
+          "line1": "1412 E 33rd St",
+          "line2": "",
+          "city": "Minneapolis",
+          "state": "MN",
+          "postalCode": "55427",
         },
-        "phoneNumber": '612-724-9989',
+        "phoneNumber": "612-724-9989",
     }
 
        fetch('https://fe-interview-technical-challenge-api-git-main-sure.vercel.app/api/policyholders', {
@@ -77,7 +86,6 @@ function PolicyholdersView() {
                 return json;
             })
             .then( (json) => dataMap.set('policyHolders', json))
-            .then(() => console.log(dataMap.has('policyHolders')))
             .catch( (err) => console.error(err))
         } else {
             setPolicyholderData(buildRows(dataMap.get('policyHolders')))
@@ -108,5 +116,23 @@ function PolicyholdersView() {
        </Box>
     )
 }
+
+// TODOs before Prod release:
+    // Users address could be formatted better.
+    // The navlink active styling should probably be less garish. 
+    // InfoTable is not the best way to display policy holders. It should be a data table with the harcoded keys passed in as the `headers` and a newly added policy would just be `pushed` to the array of policy holders.
+    // Regardless of the above `InfoTable` should be made more flexible for the `values` it takes, possibly through a generic of types such as `string | boolean | object`
+    // Clarity around button text being uppercase (as MUI default) or lowercase (as defined in the challenge requirements)
+    // Clarity around whether `Primary policyholder` should display as a `boolean` or converted to a `yes` or `no` value
+    // More robust error handling for the GET/POST call instead of just logging to the console
+    // Add Cypress tests to handle other nav links as well as the `View Challenges` button
+    // The two uses of `any` here should be fixed
+
+    /*** GLOBAL CONSIDERATIONS ***/
+    // A decision should be made about handling custom styling both globally (through `theme`) as well as locally using `styled-components`, etc. as the previous "easy" solution using MUI `makeStyles` and `useStyles` is now deprecated (https://mui.com/system/styles/basics/)
+    // The `cypress` happy path tests could remove the `intercept` call and by verifying the the table is loaded with data know that the network request was successful. This would help with performance, especially if parallelization is not used
+    // Linting rules should be enforced around whitespaces, semicolons, ternary formating, etc.
+    // Formatting rules should be enforced to prevent inconsistencies from dev to dev/ide to ide. 
+    // As the app grows a more robust data fetching solution should be used such as React Query.
 
 export default PolicyholdersView

--- a/src/components/PolicyholdersView/PolicyholdersView.tsx
+++ b/src/components/PolicyholdersView/PolicyholdersView.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { Button, Box } from '@mui/material';
 import InfoTable from '../InfoTable'
 
   type TPolicy = {
@@ -39,6 +40,30 @@ function PolicyholdersView() {
         return policyArr
     }
 
+    const postPolicy = () => {
+       const postPayload = {
+        "name": 'Derek',
+        "age": '76',
+        "address": {
+          "line1": '1412 E 33rd St',
+          "line2": '',
+          "city": 'Minneapolis',
+          "state": 'MN',
+          "postalCode": '55427',
+        },
+        "phoneNumber": '612-724-9989',
+    }
+
+       fetch('https://fe-interview-technical-challenge-api-git-main-sure.vercel.app/api/policyholders', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(postPayload)
+       })
+            .then( (response) => response.json())
+    }
+
     useEffect( () => {
         fetch('https://fe-interview-technical-challenge-api-git-main-sure.vercel.app/api/policyholders')
             .then( (response) => response.json())
@@ -47,7 +72,27 @@ function PolicyholdersView() {
 
     return (
         <>
-        {policyholderData.length > 0 ? <InfoTable header="Policyholder Details" rows={policyholderData} /> : null}
+        {
+            policyholderData.length > 0
+            ?
+                <Box
+                    textAlign='center'
+                >
+                    <InfoTable header="Policyholder Details" rows={policyholderData} /> 
+                    <Button
+                        onClick={postPolicy}
+                        variant="contained"
+                        color="primary"
+                        size="large"
+                        sx={{
+                            marginTop: '20px',
+                            textTransform: 'none'
+                        }}
+                    >
+                        Add a policyholder
+                    </Button>
+                </Box>
+            : null}
        </>
     )
 }

--- a/src/components/PolicyholdersView/PolicyholdersView.tsx
+++ b/src/components/PolicyholdersView/PolicyholdersView.tsx
@@ -1,0 +1,18 @@
+import { useEffect, useState } from 'react';
+
+function PolicyholdersView() {
+    const [policyholderData, setPolicyholderData] = useState()
+
+    console.log(policyholderData)
+    useEffect( () => {
+        fetch('https://fe-interview-technical-challenge-api-git-main-sure.vercel.app/api/policyholders')
+            .then( (response) => response.json())
+            .then( (json) => setPolicyholderData(json))
+    }, [])
+
+    return (
+        null
+    )
+}
+
+export default PolicyholdersView

--- a/src/components/PolicyholdersView/index.ts
+++ b/src/components/PolicyholdersView/index.ts
@@ -1,0 +1,1 @@
+export { default } from './PolicyholdersView';


### PR DESCRIPTION
# Summary:
  The purpose of [JIRA-123] is to flesh out the existing Sure FE Challenge application. Some of this work involves:
- Adding active functionality to navbar selections.
- GETting and POSTing policyholder data and displaying it.
- Updating unit and Cypress tests.

# Notes:
  Commit `Challenge 9: Add Policyholders happy path to cypress tests` (01322859267f5c86bd6eae0bb5813b3ca9aacb94)  is actually for `Challenge 10`.

## Development Thoughts:
- Early on I would have asked via stand-up or public chat with PM/SM about display issues around `primaryPolicyholder`, button text, and address formatting.
- I switched from MUI's `Link` to React-Router's `NavLink` because it both satisfied the desired additional functionality as well as being a better fit for `NavLink` vs `Link`. Specifically RR's `NavLink` not only has built in functionality for handling active link selecting but for the `aria-current` accessibility attribute as well (https://github.com/remix-run/react-router/pull/4708)
![Screen Shot 2023-01-14 at 12 59 30 PM](https://user-images.githubusercontent.com/6445890/212797812-1bba6a59-9193-4d27-aa90-392aee969bf3.png)

- I would have initiated a discussion on how we want to be handle data fetching. The early ask for caching seems to preview robust functionality addressed with something like `React Query`. If there wasn't a standardized process for data fetching ("In React apps we fetch data with X") I would discuss with other FE devs on the team as well as any staff/architect/managers that have a decision making role/stake in the repo.
- Likewise I would have asked how we want to handle styling outside of MUI, do we want to simply create stylesheets and import them (as I did here) or use a more robust solution such as `styled-components`?
- I would have reached out for solutions to my two uses of `any` in `PolicyholdersView`. The created types should have been sufficient, especially after attempted type narrowing. My concern is that an invalid type can pass through in an unforeseen way resulting in a runtime error.

## How to QA:
- Pull down branch
- No packages added so `yarn install` not needed.
-  Run 'yarn test` to make sure unit tests pass
- Run `yarn start`.
- Run 'yarn cy:open` from another terminal to make sure cypress tests pass.
- Selecting a link on the left nav bar should result in an active state like so: 
<img width="215" alt="Screen Shot 2023-01-16 at 8 19 28 PM" src="https://user-images.githubusercontent.com/6445890/212795556-dd8a758e-bc54-4287-9f07-47637f608462.png">
- The `Policyholders` link should automatically load in policyholder data for the user below: 
<img width="732" alt="Screen Shot 2023-01-16 at 8 20 35 PM" src="https://user-images.githubusercontent.com/6445890/212795658-a2f16a82-bf64-41ae-afa6-2ea3062ebbea.png">
- The network tab shouldn't show repeated calls to the `policyholders` endpoint when switching between tabs and selecting `Policyholders`
- Clicking the 'Add a policyholder` button should add a user and result in this:
<img width="758" alt="Screen Shot 2023-01-16 at 8 23 22 PM" src="https://user-images.githubusercontent.com/6445890/212795950-86d75543-7cce-46ca-bb50-b819fa8d9745.png">

## Rollback procedure:
Deploy an earlier version of `Main`. No other branches are dependent on the work contained here.
 